### PR TITLE
Feature: exchange rate

### DIFF
--- a/src/api/handcash_connect_service.js
+++ b/src/api/handcash_connect_service.js
@@ -91,6 +91,15 @@ module.exports = class HandCashConnectService {
       return HandCashConnectService.handleRequest(requestParameters);
    }
 
+   /**
+    * @param {String} currencyCode
+    * @returns {Promise<any>}
+    */
+   async getExchangeRate(currencyCode) {
+      const requestParameters = this.httpRequestFactory.getExchangeRateRequest(currencyCode);
+      return HandCashConnectService.handleRequest(requestParameters);
+   }
+
    static async handleRequest(requestParameters) {
       return axios(requestParameters)
          .then(response => response.data)

--- a/src/api/http_request_factory.js
+++ b/src/api/http_request_factory.js
@@ -167,4 +167,16 @@ module.exports = class HttpRequestFactory {
          queryParameters,
       );
    }
+
+   /**
+    * @param {string} currencyCode
+    * @returns {Object}
+    */
+   getExchangeRateRequest(currencyCode) {
+      return this._getSignedRequest(
+         'GET',
+         `${walletEndpoint}/exchangeRate/${currencyCode}`,
+         {},
+      );
+   }
 };

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -44,6 +44,13 @@ const HandCashConnectService = require('../api/handcash_connect_service');
  * @property {Array<Attachment>} attachments
  */
 
+/**
+ * @typedef {Object} ExchangeRate
+ * @property {string} fiatSymbol
+ * @property {number} rate
+ * @property {number} exchangeRateVersion
+ */
+
 module.exports = class Wallet {
    /**
     * @param {HandCashConnectService} handCashConnectService
@@ -78,5 +85,13 @@ module.exports = class Wallet {
     */
    async getPayment(transactionId) {
       return this.handCashConnectService.getPayment(transactionId);
+   }
+
+   /**
+    * @param {String} currencyCode
+    * @returns {Promise<ExchangeRate>}
+    */
+   async getExchangeRate(currencyCode) {
+      return this.handCashConnectService.getExchangeRate(currencyCode);
    }
 };

--- a/test/chai_extensions.js
+++ b/test/chai_extensions.js
@@ -4,7 +4,9 @@ chai.use(require('chai-as-promised'));
 const { expect } = chai;
 
 const definitionToMatch = (expectedStructure, actualStructure) => {
-   expect(actualStructure).to.have.all.keys(Object.keys(expectedStructure));
+   console.log(Object.keys(expectedStructure));
+   console.log(Object.keys(actualStructure));
+   expect(Object.keys(actualStructure)).to.include.members(Object.keys(expectedStructure));
    Object.entries(expectedStructure).forEach((value) => {
       const [name, type] = value;
       if (type instanceof Array && actualStructure[name][0] instanceof Object) {

--- a/test/chai_extensions.js
+++ b/test/chai_extensions.js
@@ -4,8 +4,6 @@ chai.use(require('chai-as-promised'));
 const { expect } = chai;
 
 const definitionToMatch = (expectedStructure, actualStructure) => {
-   console.log(Object.keys(expectedStructure));
-   console.log(Object.keys(actualStructure));
    expect(Object.keys(actualStructure)).to.include.members(Object.keys(expectedStructure));
    Object.entries(expectedStructure).forEach((value) => {
       const [name, type] = value;

--- a/test/integration/wallet/exchangeRate.api-definition.js
+++ b/test/integration/wallet/exchangeRate.api-definition.js
@@ -1,0 +1,5 @@
+module.exports = {
+   'rate': 'number',
+   'fiatSymbol': 'string',
+   'exchangeRateVersion': 'string',
+};

--- a/test/integration/wallet/wallet.test.js
+++ b/test/integration/wallet/wallet.test.js
@@ -2,6 +2,7 @@ const chai = require('../../chai_extensions');
 const paymentResultApiDefinition = require('./paymentResult.api-definition');
 const createPaymentResultApiDefinition = require('./createPaymentResult.api-definition');
 const spendableBalanceApiDefinition = require('./spendableBalance.api-definition');
+const exchangeRateApiDefinition = require('./exchangeRate.api-definition');
 
 const { HandCashConnect, HandCashConnectApiError, Environments } = require('../../../src/index');
 
@@ -82,6 +83,15 @@ describe('# Wallet - Integration Tests', () => {
 
       expect.definitionToMatch(spendableBalanceApiDefinition, spendableBalance);
       expect(spendableBalance.currencyCode)
+         .to
+         .equal('EUR');
+   });
+
+   it('should get exchange rate in EUR', async () => {
+      const exchangeRate = await this.cloudAccount.wallet.getExchangeRate('EUR');
+
+      expect.definitionToMatch(exchangeRateApiDefinition, exchangeRate);
+      expect(exchangeRate.fiatSymbol)
          .to
          .equal('EUR');
    });


### PR DESCRIPTION
## Overview

Added feature to get exchange rate conversion from a given fiat currency.

## Example

``` javascript
const exchangeRate = await account.wallet.getExchangeRate('EUR');
console.log(exchangeRate);

// {rate: 207.5712, fiatSymbol: "EUR", exchangeRateVersion: "60632df0690e870c445e3d79" }
```
