### PR TITLE
Extra query parameters

### DIFF
--- a/src/handcash_connect.js
+++ b/src/handcash_connect.js
@@ -12,10 +12,15 @@ module.exports = class HandCashConnect {
    }
 
    /**
+    * @param {object} [queryParameters]
     * @returns {String}
     */
-   getRedirectionUrl() {
-      return `${this.env.clientUrl}/#/authorizeApp?appId=${this.appId}`;
+   getRedirectionUrl(queryParameters = {}) {
+      queryParameters.appId = this.appId;
+      const encodedParams = Object.entries(queryParameters)
+         .map(([key, val]) => `${encodeURIComponent(key)}=${encodeURIComponent(val.toString())}`)
+         .join('&');
+      return `${this.env.clientUrl}/#/authorizeApp?${encodedParams}`;
    }
 
    /**

--- a/src/profile/index.js
+++ b/src/profile/index.js
@@ -11,6 +11,7 @@ const HandCashConnectService = require('../api/handcash_connect_service');
  * @property {string} displayName
  * @property {string} avatarUrl
  * @property {string} localCurrencyCode
+ * @property {string} bitcoinUnit
  */
 
 /**

--- a/test/integration/authorization/authorization.test.js
+++ b/test/integration/authorization/authorization.test.js
@@ -20,6 +20,23 @@ describe('# Authorization - Integration Tests', () => {
          .includes(appId);
    });
 
+   it('should get a redirection URL with extra query parameters', async () => {
+      const appId = '1234567890';
+      const handCashConnect = new HandCashConnect(appId, Environments.iae);
+      const redirectionLoginUrl = handCashConnect.getRedirectionUrl({ param1: 'value1' });
+
+      expect(redirectionLoginUrl)
+         .to
+         .be
+         .a('String');
+      expect(redirectionLoginUrl)
+         .includes(Environments.iae.clientUrl);
+      expect(redirectionLoginUrl)
+         .includes(appId);
+      expect(redirectionLoginUrl)
+         .includes('param1=value1');
+   });
+
    it('should get a redirection URL for default environment (prod)', async () => {
       const appId = '1234567890';
       const handCashConnect = new HandCashConnect(appId);

--- a/test/integration/profile/publicUserProfile.api-definition.js
+++ b/test/integration/profile/publicUserProfile.api-definition.js
@@ -5,4 +5,5 @@ module.exports = {
    'displayName': 'string',
    'avatarUrl': 'string',
    'localCurrencyCode': 'string',
+   'bitcoinUnit': 'string',
 };


### PR DESCRIPTION
## Overview

- Add extra query parameters to the redirect URL so when the user is redirected back to the app these parameters are included.
- Expose `bitcoinUnit` as part of users' public profile.