### PR TITLE
Add optional parameter alias to nextOwner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.9-beta] - 2021-09-01
+- Extend `HandCashOwner.nextOwner()` with an optional alias `HandCashOwner.nextOwner(alias)`. 
+
 ## [0.2.8-beta] - 2021-08-23
 - Include app-secret in the headers for the run extension endpoints.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@handcash/handcash-connect",
-  "version": "0.2.8-beta",
+  "version": "0.2.9-beta",
   "description": "HandCash Connect SDK",
   "main": "src/index.js",
   "scripts": {

--- a/src/api/handcash_connect_service.js
+++ b/src/api/handcash_connect_service.js
@@ -121,10 +121,11 @@ class HandCashConnectService {
    }
 
    /**
+    * @param {string} alias
     * @returns {Promise<any>}
     */
-   async ownerNextAddress() {
-      const requestParameters = this.httpRequestFactory.getOwnerNextAddressRequest();
+   async ownerNextAddress(alias) {
+      const requestParameters = this.httpRequestFactory.getOwnerNextAddressRequest(alias);
       return HandCashConnectService.handleRequest(requestParameters);
    }
 

--- a/src/api/http_request_factory.js
+++ b/src/api/http_request_factory.js
@@ -226,13 +226,16 @@ class HttpRequestFactory {
    }
 
    /**
+    * @param {string} alias
     * @return {Object}
     */
-   getOwnerNextAddressRequest() {
+   getOwnerNextAddressRequest(alias) {
       return this._getSignedRequest(
          'GET',
          `${runExtensionEndpoint}/owner/next`,
-         {},
+         {
+            alias,
+         },
       );
    }
 

--- a/src/run_extension/handcash_owner.js
+++ b/src/run_extension/handcash_owner.js
@@ -32,8 +32,13 @@ module.exports = class HandCashOwner {
       return new HandCashOwner(handCashConnectService);
    }
 
-   async nextOwner() {
-      const res = await this.handCashConnectService.ownerNextAddress();
+   /**
+    * @param {string} alias
+    * @param {Array<Object>} locks
+    * @returns {string}
+    */
+   async nextOwner(alias) {
+      const res = await this.handCashConnectService.ownerNextAddress(alias);
       return res.ownerAddress;
    }
 
@@ -41,7 +46,7 @@ module.exports = class HandCashOwner {
     * @param {string} rawTransaction
     * @param {Array<Object>} inputParents
     * @param {Array<Object>} locks
-    * @returns {Promise<any>}
+    * @returns {string}
     */
    async sign(rawTransaction, inputParents, locks) {
       const res = await this.handCashConnectService.ownerSign(rawTransaction, inputParents, locks);

--- a/test/integration/run_extension/handcash_owner.test.js
+++ b/test/integration/run_extension/handcash_owner.test.js
@@ -1,5 +1,7 @@
 const Run = require('run-sdk');
+const chai = require('../../chai_extensions');
 
+const { expect } = chai;
 const { HandCashOwner, HandCashPurse, Environments } = require('../../../src/index');
 const ownerTests = require('./owner_tests');
 
@@ -19,4 +21,10 @@ describe('# HandCashOwner - Integration Tests', () => {
       });
       await ownerTests(run);
    }).timeout(30000);
+
+   it('should get an address for the given alias', async () => {
+      const address = await this.handcashOwner.nextOwner('tester');
+
+      expect(address).to.be.a('string');
+   });
 });

--- a/test/integration/wallet/wallet.test.js
+++ b/test/integration/wallet/wallet.test.js
@@ -20,7 +20,7 @@ describe('# Wallet - Integration Tests', () => {
          appAction: 'test',
          payments: [
             {
-               to: 'rjseibane',
+               to: 'rafa',
                currencyCode: 'USD',
                amount: 0.005,
             },
@@ -66,7 +66,7 @@ describe('# Wallet - Integration Tests', () => {
    });
 
    it('should retrieve a previous payment result', async () => {
-      const transactionId = '211f08cd254a822810da02ac5abbb266f484721357b369914c760d4388583697';
+      const transactionId = 'c10ae3048927ba7f18864c2849d7e718899a1ba8f9aef3475b0b7453539d2ff6';
       const paymentResult = await this.cloudAccount.wallet.getPayment(transactionId);
 
       expect.definitionToMatch(paymentResultApiDefinition, paymentResult);


### PR DESCRIPTION
## Overview

- Extend `HandCashOwner.nextOwner()` with an optional alias `HandCashOwner.nextOwner(alias)`.