### PR TITLE
Use Environments.prod by default

### DIFF
--- a/src/handcash_connect.js
+++ b/src/handcash_connect.js
@@ -1,4 +1,5 @@
 const HandCashCloudAccount = require('./handcash_cloud_account');
+const Environments = require('./environments');
 
 /**
  * @typedef {Object} HandCashInitParameters
@@ -17,7 +18,7 @@ class HandCashConnect {
    constructor(params) {
       this.appId = params.appId;
       this.appSecret = params.appSecret;
-      this.env = params.env;
+      this.env = params.env || Environments.prod;
    }
 
    /**

--- a/test/unit/api/handcash_connect.test.js
+++ b/test/unit/api/handcash_connect.test.js
@@ -1,0 +1,17 @@
+const chai = require('../../chai_extensions');
+
+const { Environments, HandCashConnect } = require('../../../src/index');
+
+const { expect } = chai;
+
+describe('# HandCashConnect - Unit Tests', () => {
+   it('should initialize with default environment', async () => {
+      const appId = '1234567890';
+      const appSecret = '1234567890';
+      const handCashConnect = new HandCashConnect({
+         appId,
+         appSecret,
+      });
+      expect(handCashConnect.env).to.eq(Environments.prod);
+   });
+});


### PR DESCRIPTION
## Overview

- Assign `Environments.prod` by default in case no `env` is specified.