### PR TITLE
Update `PaymentResult` Interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -172,6 +172,7 @@ export interface PaymentResult {
     fiatCurrencyCode: string;
     participants: TransactionParticipant[];
     attachments: Attachment[];
+    rawTransactionHex?: string;
 }
 
 export interface ExchangeRate {


### PR DESCRIPTION
Update `PaymentResult` interface to include an optional `rawTransactionHex` attribute. It is optional as it is only available after calling `pay` but not `getPayment`.