### PR TITLE
Export remaining types in payments.ts

### DIFF
--- a/src/types/payments.ts
+++ b/src/types/payments.ts
@@ -1,18 +1,18 @@
 import { CurrencyCode } from './currencyCode';
 
-type PaymentRequestItem = {
+export type PaymentRequestItem = {
 	destination: string;
 	currencyCode: CurrencyCode;
 	sendAmount: number;
 	tags?: [];
 };
 
-type Attachment = {
+export type Attachment = {
 	value: string | object;
 	format: 'base64' | 'hex' | 'json';
 };
 
-type TransactionParticipant = {
+export type TransactionParticipant = {
 	type: string;
 	alias: string;
 	displayName: number;


### PR DESCRIPTION
pre-1.0.0-rc versions, `PaymentRequestItem`, `Attachment` and `TransactionParticipant` were exported. Update the these types to be exported so consumers can have type safety when building a complete PaymentParameters object.