### PR TITLE
Expose app id with the granted permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.12] - 2023-04-14
+
+-   New function in profile to get app permissions along with the app id (`getPermissionsInfo`). 
+
+## [0.6.11] - 2023-04-11
+
+-   Fix string conversion causing an issue with `getEncryptionKeypair()`
+
 ## [0.6.10] - 2023-03-31
 
 -   Fix data type transformation causing an issue with `getEncryptionKeypair()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@handcash/handcash-connect",
-	"version": "0.6.11",
+	"version": "0.6.12",
 	"description": "HandCash Connect SDK",
 	"type": "module",
 	"main": "./index.umd.cjs",

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -1,6 +1,6 @@
 import { PrivateKey, ECIES, ECIESCiphertext, PublicKey } from 'bsv-wasm';
 import HandCashConnectService from '../api/handcash_connect_service';
-import { Permissions, UserProfile, UserPublicProfile } from '../types/account';
+import { Permissions, PermissionsInfo, UserProfile, UserPublicProfile } from '../types/account';
 import { KeyPair } from '../types/bsv';
 import { DataSignature, DataSignatureParameters } from '../types/signature';
 
@@ -54,6 +54,17 @@ export default class Profile {
 	 */
 	async getPermissions(): Promise<Permissions[]> {
 		return this.handCashConnectService.getUserPermissions().then((result) => result.items);
+	}
+
+	/**
+	 *
+	 * Returns the permissions granted to the app by the user along with the app id.
+	 *
+	 * @returns {Promise<PermissionsInfo>} A promise that resolves to PermissionsInfo.
+	 *
+	 */
+	async getPermissionsInfo(): Promise<PermissionsInfo> {
+		return this.handCashConnectService.getUserPermissions().then((result) => result);
 	}
 
 	/**

--- a/src/test/integration/profile/profile.spec.ts
+++ b/src/test/integration/profile/profile.spec.ts
@@ -36,13 +36,31 @@ describe('# Profile - Integration Tests', () => {
 
 	it('should get current user permissions', async () => {
 		const userPermissions = await cloudAccount.profile.getPermissions();
-		expect(userPermissions).toContain(Permissions.Pay);
-		expect(userPermissions).toContain(Permissions.UserPublicProfile);
-		expect(userPermissions).toContain(Permissions.UserPrivateProfile);
-		expect(userPermissions).toContain(Permissions.Friends);
-		expect(userPermissions).toContain(Permissions.Decrypt);
-		expect(userPermissions).toContain(Permissions.SignData);
-		expect(userPermissions).toContain(Permissions.ReadBalance);
+		const expectedPermissions = [
+			Permissions.Pay,
+			Permissions.UserPublicProfile,
+			Permissions.UserPrivateProfile,
+			Permissions.Friends,
+			Permissions.Decrypt,
+			Permissions.SignData,
+			Permissions.ReadBalance,
+		];
+		expect(userPermissions).containSubset(expectedPermissions);
+	});
+
+	it('should get current permissions info', async () => {
+		const userPermissions = await cloudAccount.profile.getPermissionsInfo();
+		const expectedPermissions = [
+			Permissions.Pay,
+			Permissions.UserPublicProfile,
+			Permissions.UserPrivateProfile,
+			Permissions.Friends,
+			Permissions.Decrypt,
+			Permissions.SignData,
+			Permissions.ReadBalance,
+		];
+		expect(userPermissions.items).containSubset(expectedPermissions);
+		expect(userPermissions.appId).to.eq(handcashAppId);
 	});
 
 	it('should get user encryption keypair', async () => {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -47,3 +47,8 @@ export enum Permissions {
 	SignData = 'SIGN_DATA',
 	ReadBalance = 'READ_BALANCE',
 }
+
+export type PermissionsInfo = {
+	items: Permissions[];
+	appId: string;
+};


### PR DESCRIPTION
## Overview

- Expose app id with the granted permissions so developers can verify that the given token belongs to their app.