### PR TITLE
Fix serialization issue in HTTP requests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,13 +13,16 @@ jobs:
               with:
                   node-version: '16.x'
             - name: npm install
-              run: |
-                  npm install --no-fund
-              env:
-                  test_authToken: ${{secrets.TEST_AUTHTOKEN}}
-                  app_secret: ${{secrets.APP_SECRET}}
-                  app_id: ${{secrets.APP_ID}}
+              run: npm install --no-fund
             - name: Unit tests
               run: npm run test
+              env:
+                test_authToken: ${{secrets.TEST_AUTHTOKEN}}
+                app_secret: ${{secrets.APP_SECRET}}
+                app_id: ${{secrets.APP_ID}}
             - name: Coverage
               run: npm run coverage
+              env:
+                test_authToken: ${{secrets.TEST_AUTHTOKEN}}
+                app_secret: ${{secrets.APP_SECRET}}
+                app_id: ${{secrets.APP_ID}}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,7 +12,7 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: '16.x'
-            - name: npm install, and test
+            - name: npm install
               run: |
                   npm install --no-fund
                   npm run coverage
@@ -20,3 +20,7 @@ jobs:
                   test_authToken: ${{secrets.TEST_AUTHTOKEN}}
                   app_secret: ${{secrets.APP_SECRET}}
                   app_id: ${{secrets.APP_ID}}
+            - name: Unit tests
+              run: npm run test
+            - name: Coverage
+              run: npm run coverage

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,7 +15,6 @@ jobs:
             - name: npm install
               run: |
                   npm install --no-fund
-                  npm run coverage
               env:
                   test_authToken: ${{secrets.TEST_AUTHTOKEN}}
                   app_secret: ${{secrets.APP_SECRET}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.15] - 2023-04-27
+
+-   Fix serialization issue affecting some endpoints.
+
 ## [0.6.14] - 2023-04-22
 
 -   Better `Attachment` type definition.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@handcash/handcash-connect",
-	"version": "0.6.14",
+	"version": "0.6.15",
 	"description": "HandCash Connect SDK",
 	"type": "module",
 	"main": "./index.umd.cjs",

--- a/src/api/handcash_connect_service.ts
+++ b/src/api/handcash_connect_service.ts
@@ -129,6 +129,7 @@ export default class HandCashConnectService {
 	}
 
 	static handleApiError(errorResponse: { response?: { status: number; data: { message: string; info: string } } }) {
+		/* c8 ignore next 3 */
 		if (!errorResponse.response || !errorResponse.response.status) {
 			return Promise.reject(errorResponse);
 		}

--- a/src/api/http_request_factory.ts
+++ b/src/api/http_request_factory.ts
@@ -63,8 +63,11 @@ export default class HttpRequestFactory {
 		const headers: Record<string, string> = {
 			'app-id': this.appId,
 			'app-secret': this.appSecret,
-			'content-type': 'application/json',
+			accept: 'application/json',
 		};
+		if (serializedBody.length > 0) {
+			headers['content-type'] = 'application/json';
+		}
 		if (this.privateKey) {
 			const publicKey = this.privateKey.to_public_key();
 			headers['oauth-publickey'] = publicKey.to_hex();

--- a/src/test/unit/http_request_factory.spec.ts
+++ b/src/test/unit/http_request_factory.spec.ts
@@ -18,4 +18,32 @@ describe('# HttpRequestFactory - Unit Tests', () => {
 				})
 		).to.throw('Invalid authToken');
 	});
+
+	it('should raise a missing appId error', async () => {
+		const appSecret = '1234567890';
+		const appId = '';
+		return expect(
+			() =>
+				new HttpRequestFactory({
+					baseApiEndpoint: Environments.iae.apiEndpoint,
+					baseTrustholderEndpoint: Environments.iae.trustholderEndpoint,
+					appSecret,
+					appId,
+				})
+		).to.throw('Missing appId');
+	});
+
+	it('should raise a missing appSecret error', async () => {
+		const appSecret = '';
+		const appId = 'id1';
+		return expect(
+			() =>
+				new HttpRequestFactory({
+					baseApiEndpoint: Environments.iae.apiEndpoint,
+					baseTrustholderEndpoint: Environments.iae.trustholderEndpoint,
+					appSecret,
+					appId,
+				})
+		).to.throw('Missing appSecret');
+	});
 });


### PR DESCRIPTION
## Issue
The server was rejecting requests with an empty body that define a `content-type` header as JSON as it expects an empty body to be consistent with the defined type.

## Solution
- Add `accept` header
- Add `content-type` header only if there is a body in the request