### PR TITLE
reach parody with cloud validator

### DIFF
--- a/src/types/items.ts
+++ b/src/types/items.ts
@@ -71,16 +71,25 @@ export type AttributeFilter = {
 	value: string | number;
 };
 
+export const sortableFields = {
+	name: 'name',
+};
+
 export type GetItemsFilter = {
-	from: number;
-	to: number;
-	sort?: 'asc' | 'desc';
-	order?: 'name';
+	from?: number;
+	to?: number;
 	collectionId?: string;
-	isVerified?: boolean;
 	searchString?: string;
-	attributes?: AttributeFilter[];
+	groupingValue?: string;
 	fetchAttributes?: boolean;
+	sort?: keyof typeof sortableFields;
+	order?: 'asc' | 'desc';
+	attributes?: AttributeFilter[];
+	isHandcashCreated?: boolean;
+	isVerified?: boolean;
+	appId?: string;
+	group?: boolean;
+	externalId?: string;
 };
 
 export type File = {


### PR DESCRIPTION
To reach feature parody with the `GetItemsValidator` in cloud

`isVerified` and `isHandcashCreated` I wonder about.

Also have 1 question for @eye1, has anything changed with passing attribute filters? I feel like there is a common complaint of it not working as expected.  Should something more be done here?