### PR TITLE
Extend account creation and migrate to named params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.10] - 2025-02-25
+#### Added
+-   New method to create accounts: `handCashConnect.createAccount({...})` - With named parameters
+
+#### Deprecated
+-   Previous method to create accounts: `handCashConnect.createNewAccount(...)` - With positioned parameters
+
 ## [0.8.9] - 2024-10-17
 -   Extended wallet to get deposit address: `account.wallet.getDepositAddress()`.
 

--- a/docs/createAccount.md
+++ b/docs/createAccount.md
@@ -1,0 +1,46 @@
+# Creating HandCash Accounts
+
+To create a new HandCash account programmatically, you'll need to follow these steps:
+
+1. Request an email verification code
+2. Generate an authentication key pair
+3. Verify the email code
+4. Create the account
+
+Here's a complete example:
+
+```typescript
+
+const handCashConnect = new HandCashConnect({
+ appId: handcashAppId,
+ appSecret: handcashAppSecret
+});
+
+// 1. Request an email verification code
+const email = 'app.review@handcash.io';
+const requestId = await handCashConnect.requestEmailCode(email);
+
+// 2. Generate an authentication key pair
+const keyPair = handCashConnect.generateAuthenticationKeyPair();
+
+// 3. Verify the email code
+const verificationCode = '12345678';
+await handCashConnect.verifyEmailCode(requestId, verificationCode, keyPair.publicKey);
+
+// 4. Create the account
+await handCashConnect.createAccount({
+ accessPublicKey: keyPair.publicKey,
+    email,
+});
+
+// Use the SDK as usual
+const cloudAccount = handCashConnect.getAccountFromAuthToken(keyPair.privateKey);
+const profileFromAuthToken = await cloudAccount.profile.getCurrentProfile();
+```
+
+## Next steps
+After creating the new account, store the `keyPair.privateKey` in a safe place. It will allow you to access the user account later on.
+
+Don't worry if you lose the access key. You can still redirect the user to HandCash to grant access to your application. It will give you a new access token.
+
+> For more details, follow the instructions to connect existing HandCash accounts to your application.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@handcash/handcash-connect",
-	"version": "0.8.9",
+	"version": "0.8.10",
 	"description": "HandCash Connect SDK",
 	"type": "module",
 	"exports": {

--- a/src/api/handcash_connect_service.ts
+++ b/src/api/handcash_connect_service.ts
@@ -309,12 +309,8 @@ export default class HandCashConnectService {
 		return HandCashConnectService.handleRequest<void>(requestParameters, new Error().stack);
 	}
 
-	async createNewAccount(accessPublicKey: string, email: string, referrerAlias?: string) {
-		const requestParameters = this.getRequest('POST', '/v1/connect/account', {
-			accessPublicKey,
-			email,
-			referrerAlias,
-		});
+	async createNewAccount(params: { accessPublicKey: string; email: string; alias?: string }) {
+		const requestParameters = this.getRequest('POST', '/v1/connect/account', params);
 		return HandCashConnectService.handleRequest<UserPublicProfile>(requestParameters, new Error().stack);
 	}
 

--- a/src/handcash_connect.ts
+++ b/src/handcash_connect.ts
@@ -133,16 +133,37 @@ export default class HandCashConnect {
 
 	/**
 	 * Creates a new account for the verified email along with some authentication public key.
-	 *
+	 * @deprecated Use createAccount instead
+	 * 
 	 * @param {string} accessPublicKey - The access public key of the user.
 	 * @param {string} email - The email address of the user.
-	 * @param {string} [referrerAlias] - Optional: The alias of the user that referred the new user.
 	 *
 	 * @returns {Object} UserPublicProfile - The user's public profile.
 	 *
 	 */
-	createNewAccount(accessPublicKey: string, email: string, referrerAlias?: string): Promise<UserPublicProfile> {
-		return this.handCashConnectService.createNewAccount(accessPublicKey, email, referrerAlias);
+	createNewAccount(accessPublicKey: string, email: string): Promise<UserPublicProfile> {
+		return this.handCashConnectService.createNewAccount({
+			accessPublicKey, email,
+		});
+	}
+
+	/**
+	 * Creates a new account for the verified email along with some authentication public key.
+	 *
+	 * @param {Object} params - The parameters for creating a new account
+	 * @param {string} params.accessPublicKey - The access public key of the user.
+	 * @param {string} params.email - The email address of the user.
+	 * @param {string} [params.alias] - Optional: The alias of the user for the new account. Example: satoshi.33
+	 *
+	 * @returns {Object} UserPublicProfile - The user's public profile.
+	 *
+	 */
+	createAccount(params: {
+		accessPublicKey: string;
+		email: string;
+		alias?: string;
+	}): Promise<UserPublicProfile> {
+		return this.handCashConnectService.createNewAccount(params);
 	}
 
 	/**

--- a/src/test/integration/handcash_connect.spec.ts
+++ b/src/test/integration/handcash_connect.spec.ts
@@ -16,7 +16,10 @@ describe('# HandCash Connect - Integration Tests', () => {
 		const keyPair = handCashConnect.generateAuthenticationKeyPair();
 		const requestId = await handCashConnect.requestEmailCode(email);
 		await handCashConnect.verifyEmailCode(requestId, verificationCode, keyPair.publicKey);
-		const createdProfile = await handCashConnect.createNewAccount(keyPair.publicKey, email);
+		const createdProfile = await handCashConnect.createAccount({
+			accessPublicKey: keyPair.publicKey,
+			email,
+		});
 
 		expect(createdProfile.id).toBeTypeOf('string');
 


### PR DESCRIPTION
## Overview

#### Added
-   New method to create accounts: `handCashConnect.createAccount({...})` - With named parameters

#### Deprecated
-   Previous method to create accounts: `handCashConnect.createNewAccount(...)` - With positioned parameters